### PR TITLE
Patch to make GetConfigurationValues tolerant of values provided by third party vendors that don't have an Id or Url associated with them

### DIFF
--- a/AppHarbor.Net/AppHarborApi.cs
+++ b/AppHarbor.Net/AppHarborApi.cs
@@ -109,7 +109,7 @@ namespace AppHarbor
         private static long ExtractLongID(string url)
         {
             if (url == null)
-                throw new ArgumentNullException("url");
+                return 0L;
 
             return Convert.ToInt64(ExtractID(url));
         }
@@ -117,11 +117,11 @@ namespace AppHarbor
         private static string ExtractID(string url)
         {
             if (url == null)
-                throw new ArgumentNullException("url");
+                return string.Empty;
 
             return url.Split('/').Last();
-        }
-
+        }         
+ 
         private T ExecuteGet<T>(RestRequest request)
             where T : new()
         {


### PR DESCRIPTION
I signed up for CloudAMQP (RabbitMQ), and was given a config value without an id or url.  GetConfigurationValues was throwing a null reference exception because the Url returned with the value from AppHarbor is null.  With my change, the API is now tolerant of such missing data, but obviously if I attempt to subsequently retrieve the variable with an Id of 0, I will get a null value back.

If you use your browser and pull https://appharbor.com/applications/YOURAPP/configurationvariables/0, AppHarbor replies with:
{
  "key": null,
  "value": null
}

Also, when I went to run the tests, it looks like there's a lot of broken tests.  I didn't write a test for my change.
