### PR TITLE
Change: ID type should be a string instead of a long

### DIFF
--- a/AppHarbor.Net/AppHarborApi.cs
+++ b/AppHarbor.Net/AppHarborApi.cs
@@ -144,7 +144,7 @@ namespace AppHarbor
             if (data == null)
                 return null;
 
-            data.ID = ExtractLongID(response.ResponseUri.LocalPath);
+            data.ID = ExtractID(response.ResponseUri.LocalPath);
 
             if (data is IUrl)
             {
@@ -165,7 +165,7 @@ namespace AppHarbor
 
             foreach (var item in data)
             {
-                item.ID = ExtractLongID(item.Url);
+                item.ID = ExtractID(item.Url);
             }
 
             return data;

--- a/AppHarbor.Net/Model/Build.cs
+++ b/AppHarbor.Net/Model/Build.cs
@@ -7,7 +7,7 @@ namespace AppHarbor.Model
 {
     public class Build : IUrl, IKeyed
     {
-        public long ID { get; set; }
+        public string ID { get; set; }
 
         public string Status { get; set; }
 

--- a/AppHarbor.Net/Model/Collaborator.cs
+++ b/AppHarbor.Net/Model/Collaborator.cs
@@ -7,7 +7,7 @@ namespace AppHarbor.Model
 {
     public class Collaborator : IUrl, IKeyed
     {
-        public long ID { get; set; }
+        public string ID { get; set; }
 
         public UserClass User { get; set; }
 

--- a/AppHarbor.Net/Model/ConfigurationVariable.cs
+++ b/AppHarbor.Net/Model/ConfigurationVariable.cs
@@ -7,7 +7,7 @@ namespace AppHarbor.Model
 {
     public class ConfigurationVariable : IUrl, IKeyed
     {
-        public long ID { get; set; }
+        public string ID { get; set; }
 
         public string Key { get; set; }
 

--- a/AppHarbor.Net/Model/Error.cs
+++ b/AppHarbor.Net/Model/Error.cs
@@ -7,7 +7,7 @@ namespace AppHarbor.Model
 {
     public class Error : IKeyed, IUrl
     {
-        public long ID { get; set; }
+        public string ID { get; set; }
 
         public string Commit_ID { get; set; }
 

--- a/AppHarbor.Net/Model/Hostname.cs
+++ b/AppHarbor.Net/Model/Hostname.cs
@@ -7,7 +7,7 @@ namespace AppHarbor.Model
 {
     public class Hostname : IUrl, IKeyed
     {
-        public long ID { get; set; }
+        public string ID { get; set; }
 
         public string Value { get; set; }
 

--- a/AppHarbor.Net/Model/IKeyed.cs
+++ b/AppHarbor.Net/Model/IKeyed.cs
@@ -7,6 +7,6 @@ namespace AppHarbor.Model
 {
     public interface IKeyed
     {
-        long ID { get; set; }
+        string ID { get; set; }
     }
 }

--- a/AppHarbor.Net/Model/ServiceHook.cs
+++ b/AppHarbor.Net/Model/ServiceHook.cs
@@ -7,7 +7,7 @@ namespace AppHarbor.Model
 {
     public class ServiceHook : IUrl, IKeyed
     {
-        public long ID { get; set; }
+        public string ID { get; set; }
 
         public string Value { get; set; }
 

--- a/AppHarbor.Test/MockedApiTests.cs
+++ b/AppHarbor.Test/MockedApiTests.cs
@@ -161,7 +161,7 @@ namespace AppHarbor.Test
         {
             var edited = Api.EditCollaborator(ApplicationID, new Model.Collaborator()
                 {
-                    ID = 5,
+                    ID = 5.ToString(),
                     Role = Model.CollaboratorType.Collaborator,
                 });
             Assert.IsTrue(edited);
@@ -172,7 +172,7 @@ namespace AppHarbor.Test
         {
             var edited = Api.EditCollaborator(ApplicationID, new Model.Collaborator()
             {
-                ID = 6,
+                ID = 6.ToString(),
                 Role = Model.CollaboratorType.Collaborator,
             });
             Assert.IsFalse(edited);
@@ -183,7 +183,7 @@ namespace AppHarbor.Test
         {
             var edited = Api.EditConfigurationVariable(ApplicationID, new Model.ConfigurationVariable()
             {
-                ID = 5,
+                ID = 5.ToString(),
                 Key = "somekey",
                 Value = "somevalue",
             });
@@ -195,7 +195,7 @@ namespace AppHarbor.Test
         {
             var edited = Api.EditConfigurationVariable(ApplicationID, new Model.ConfigurationVariable()
             {
-                ID = 6,
+                ID = 6.ToString(),
                 Key = "somekey",
                 Value = "somevalue",
             });


### PR DESCRIPTION
For example the Error model must be a string there the id is a string, so long will not be usable there.
