### PR TITLE
Change application id to application slug

### DIFF
--- a/AppHarbor.Sdk/AppHarborClient.Application.cs
+++ b/AppHarbor.Sdk/AppHarborClient.Application.cs
@@ -14,13 +14,13 @@ namespace AppHarbor
 			return ExecuteGet<List<Application>>(request);
 		}
 
-		public Application GetApplication(string applicationId)
+		public Application GetApplication(string applicationSlug)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			return ExecuteGet<Application>(request);
 		}
 
@@ -47,16 +47,16 @@ namespace AppHarbor
 			return ExecuteCreateApplication(request);
 		}
 
-		public bool EditApplication(string applicationId, Application application)
+		public bool EditApplication(string applicationSlug, Application application)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 			CheckArgumentNull("application", application);
 			CheckArgumentNull("application.Name", application.Name);
 
 			var request = new RestRequest(Method.PUT);
 			request.RequestFormat = DataFormat.Json;
-			request.Resource = "applications/{applicationId}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddBody(new
 			{
 				name = application.Name,
@@ -64,13 +64,13 @@ namespace AppHarbor
 			return ExecuteEdit(request);
 		}
 
-		public bool DeleteApplication(string applicationId)
+		public bool DeleteApplication(string applicationSlug)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest(Method.DELETE);
-			request.Resource = "applications/{applicationId}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 
 			return ExecuteDelete(request);
 		}

--- a/AppHarbor.Sdk/AppHarborClient.Build.cs
+++ b/AppHarbor.Sdk/AppHarborClient.Build.cs
@@ -6,25 +6,25 @@ namespace AppHarbor
 {
 	public partial class AppHarborClient
 	{
-		public Build GetBuild(string applicationId, string id)
+		public Build GetBuild(string applicationSlug, string id)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/builds/{id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/builds/{id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("id", id, ParameterType.UrlSegment);
 
 			return ExecuteGetKeyed<Build>(request);
 		}
 
-		public IEnumerable<Build> GetBuilds(string applicationId)
+		public IEnumerable<Build> GetBuilds(string applicationSlug)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/builds";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/builds";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 
 			return ExecuteGetListKeyed<Build>(request);
 		}

--- a/AppHarbor.Sdk/AppHarborClient.Collaborator.cs
+++ b/AppHarbor.Sdk/AppHarborClient.Collaborator.cs
@@ -7,32 +7,32 @@ namespace AppHarbor
 {
 	public partial class AppHarborClient
 	{
-		public Collaborator GetCollaborator(string applicationId, string id)
+		public Collaborator GetCollaborator(string applicationSlug, string id)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/collaborators/{id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/collaborators/{id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("id", id, ParameterType.UrlSegment);
 
 			return ExecuteGetKeyed<Collaborator>(request);
 		}
 
-		public IEnumerable<Collaborator> GetCollaborators(string applicationId)
+		public IEnumerable<Collaborator> GetCollaborators(string applicationSlug)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/collaborators";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/collaborators";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 
 			return ExecuteGetListKeyed<Collaborator>(request);
 		}
 
-		public CreateResult CreateCollaborator(string applicationId, string email, CollaboratorType collaboratorType)
+		public CreateResult CreateCollaborator(string applicationSlug, string email, CollaboratorType collaboratorType)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 			CheckArgumentNull("email", email);
 
 			if (collaboratorType == CollaboratorType.None)
@@ -42,8 +42,8 @@ namespace AppHarbor
 
 			var request = new RestRequest(Method.POST);
 			request.RequestFormat = DataFormat.Json;
-			request.Resource = "applications/{applicationId}/collaborators";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/collaborators";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddBody(new
 			{
 				collaboratorEmail = email,
@@ -52,9 +52,9 @@ namespace AppHarbor
 			return ExecuteCreate(request);
 		}
 
-		public bool EditCollaborator(string applicationId, Collaborator collaborator)
+		public bool EditCollaborator(string applicationSlug, Collaborator collaborator)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 			CheckArgumentNull("collaborator", collaborator);
 			CheckArgumentNull("collaborator.Role", collaborator.Role);
 
@@ -65,8 +65,8 @@ namespace AppHarbor
 
 			var request = new RestRequest(Method.PUT);
 			request.RequestFormat = DataFormat.Json;
-			request.Resource = "applications/{applicationId}/collaborators/{id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/collaborators/{id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("id", collaborator.Id, ParameterType.UrlSegment);
 			request.AddBody(new
 			{
@@ -75,13 +75,13 @@ namespace AppHarbor
 			return ExecuteEdit(request);
 		}
 
-		public bool DeleteCollaborator(string applicationId, string id)
+		public bool DeleteCollaborator(string applicationSlug, string id)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest(Method.DELETE);
-			request.Resource = "applications/{applicationId}/collaborators/{id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/collaborators/{id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("id", id, ParameterType.UrlSegment);
 
 			return ExecuteDelete(request);

--- a/AppHarbor.Sdk/AppHarborClient.ConfigurationVariable.cs
+++ b/AppHarbor.Sdk/AppHarborClient.ConfigurationVariable.cs
@@ -6,39 +6,39 @@ namespace AppHarbor
 {
 	public partial class AppHarborClient
 	{
-		public ConfigurationVariable GetConfigurationVariable(string applicationId, string id)
+		public ConfigurationVariable GetConfigurationVariable(string applicationSlug, string id)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/configurationvariables/{id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/configurationvariables/{id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("id", id, ParameterType.UrlSegment);
 
 			return ExecuteGetKeyed<ConfigurationVariable>(request);
 		}
 
-		public IEnumerable<ConfigurationVariable> GetConfigurationVariables(string applicationId)
+		public IEnumerable<ConfigurationVariable> GetConfigurationVariables(string applicationSlug)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/configurationvariables";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/configurationvariables";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 
 			return ExecuteGetListKeyed<ConfigurationVariable>(request);
 		}
 
-		public CreateResult CreateConfigurationVariable(string applicationId, string key, string value)
+		public CreateResult CreateConfigurationVariable(string applicationSlug, string key, string value)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 			CheckArgumentNull("key", key);
 			CheckArgumentNull("value", value);
 
 			var request = new RestRequest(Method.POST);
 			request.RequestFormat = DataFormat.Json;
-			request.Resource = "applications/{applicationId}/configurationvariables";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/configurationvariables";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddBody(new
 			{
 				key = key,
@@ -47,17 +47,17 @@ namespace AppHarbor
 			return ExecuteCreate(request);
 		}
 
-		public bool EditConfigurationVariable(string applicationId, ConfigurationVariable configurationVariable)
+		public bool EditConfigurationVariable(string applicationSlug, ConfigurationVariable configurationVariable)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 			CheckArgumentNull("configurationVariable", configurationVariable);
 			CheckArgumentNull("configurationVariable.Key ", configurationVariable.Key);
 			CheckArgumentNull("configurationVariable.Value", configurationVariable.Value);
 
 			var request = new RestRequest(Method.PUT);
 			request.RequestFormat = DataFormat.Json;
-			request.Resource = "applications/{applicationId}/configurationvariables/{id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/configurationvariables/{id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("id", configurationVariable.Id, ParameterType.UrlSegment);
 			request.AddBody(new
 			{
@@ -67,13 +67,13 @@ namespace AppHarbor
 			return ExecuteEdit(request);
 		}
 
-		public bool DeleteConfigurationVariable(string applicationId, string id)
+		public bool DeleteConfigurationVariable(string applicationSlug, string id)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest(Method.DELETE);
-			request.Resource = "applications/{applicationId}/configurationvariables/{id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/configurationvariables/{id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("id", id, ParameterType.UrlSegment);
 
 			return ExecuteDelete(request);

--- a/AppHarbor.Sdk/AppHarborClient.Error.cs
+++ b/AppHarbor.Sdk/AppHarborClient.Error.cs
@@ -6,25 +6,25 @@ namespace AppHarbor
 {
 	public partial class AppHarborClient
 	{
-		public Error GetError(string applicationId, string id)
+		public Error GetError(string applicationSlug, string id)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/errors/{Id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/errors/{Id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("Id", id, ParameterType.UrlSegment);
 
 			return ExecuteGetKeyed<Error>(request);
 		}
 
-		public IEnumerable<Error> GetErrors(string applicationId)
+		public IEnumerable<Error> GetErrors(string applicationSlug)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/errors";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/errors";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 
 			return ExecuteGetListKeyed<Error>(request);
 		}

--- a/AppHarbor.Sdk/AppHarborClient.Hostname.cs
+++ b/AppHarbor.Sdk/AppHarborClient.Hostname.cs
@@ -6,38 +6,38 @@ namespace AppHarbor
 {
 	public partial class AppHarborClient
 	{
-		public Hostname GetHostname(string applicationId, string Id)
+		public Hostname GetHostname(string applicationSlug, string Id)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/hostnames/{Id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/hostnames/{Id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("Id", Id, ParameterType.UrlSegment);
 
 			return ExecuteGetKeyed<Hostname>(request);
 		}
 
-		public IEnumerable<Hostname> GetHostnames(string applicationId)
+		public IEnumerable<Hostname> GetHostnames(string applicationSlug)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/hostnames";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/hostnames";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 
 			return ExecuteGetListKeyed<Hostname>(request);
 		}
 
-		public CreateResult CreateHostname(string applicationId, string hostName)
+		public CreateResult CreateHostname(string applicationSlug, string hostName)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 			CheckArgumentNull("hostName", hostName);
 
 			var request = new RestRequest(Method.POST);
 			request.RequestFormat = DataFormat.Json;
-			request.Resource = "applications/{applicationId}/hostnames";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/hostnames";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddBody(new
 			{
 				value = hostName,
@@ -45,13 +45,13 @@ namespace AppHarbor
 			return ExecuteCreate(request);
 		}
 
-		public bool DeleteHostname(string applicationId, string Id)
+		public bool DeleteHostname(string applicationSlug, string Id)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest(Method.DELETE);
-			request.Resource = "applications/{applicationId}/hostnames/{Id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/hostnames/{Id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("Id", Id, ParameterType.UrlSegment);
 
 			return ExecuteDelete(request);

--- a/AppHarbor.Sdk/AppHarborClient.ServiceHooks.cs
+++ b/AppHarbor.Sdk/AppHarborClient.ServiceHooks.cs
@@ -6,38 +6,38 @@ namespace AppHarbor
 {
 	public partial class AppHarborClient
 	{
-		public ServiceHook GetServicehook(string applicationId, string Id)
+		public ServiceHook GetServicehook(string applicationSlug, string Id)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/servicehooks/{Id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/servicehooks/{Id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("Id", Id, ParameterType.UrlSegment);
 
 			return ExecuteGetKeyed<ServiceHook>(request);
 		}
 
-		public IEnumerable<ServiceHook> GetServicehooks(string applicationId)
+		public IEnumerable<ServiceHook> GetServicehooks(string applicationSlug)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/servicehooks";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/servicehooks";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 
 			return ExecuteGetListKeyed<ServiceHook>(request);
 		}
 
-		public CreateResult CreateServicehook(string applicationId, string url)
+		public CreateResult CreateServicehook(string applicationSlug, string url)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 			CheckArgumentNull("url", url);
 
 			var request = new RestRequest(Method.POST);
 			request.RequestFormat = DataFormat.Json;
-			request.Resource = "applications/{applicationId}/servicehooks";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/servicehooks";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddBody(new
 			{
 				url = url,
@@ -45,13 +45,13 @@ namespace AppHarbor
 			return ExecuteCreate(request);
 		}
 
-		public bool DeleteServicehook(string applicationId, string Id)
+		public bool DeleteServicehook(string applicationSlug, string Id)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest(Method.DELETE);
-			request.Resource = "applications/{applicationId}/servicehooks/{Id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/servicehooks/{Id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("Id", Id, ParameterType.UrlSegment);
 
 			return ExecuteDelete(request);

--- a/AppHarbor.Sdk/AppHarborClient.Test.cs
+++ b/AppHarbor.Sdk/AppHarborClient.Test.cs
@@ -6,27 +6,27 @@ namespace AppHarbor
 {
 	public partial class AppHarborClient
 	{
-		public Test GetTest(string applicationId, string buildId, string Id)
+		public Test GetTest(string applicationSlug, string buildId, string Id)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 			CheckArgumentNull("Id", Id);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/builds/{buildId}/tests/{Id}";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/builds/{buildId}/tests/{Id}";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("buildId", buildId, ParameterType.UrlSegment);
 			request.AddParameter("Id", Id, ParameterType.UrlSegment);
 
 			return ExecuteGet<Test>(request);
 		}
 
-		public IEnumerable<Test> GetTests(string applicationId, string buildId)
+		public IEnumerable<Test> GetTests(string applicationSlug, string buildId)
 		{
-			CheckArgumentNull("applicationId", applicationId);
+			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationId}/builds/{buildId}/tests";
-			request.AddParameter("applicationId", applicationId, ParameterType.UrlSegment);
+			request.Resource = "applications/{applicationSlug}/builds/{buildId}/tests";
+			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
 			request.AddParameter("buildId", buildId, ParameterType.UrlSegment);
 
 			return ExecuteGet<List<Test>>(request);

--- a/AppHarbor.Test/IntegrationTests.cs
+++ b/AppHarbor.Test/IntegrationTests.cs
@@ -59,7 +59,7 @@ namespace AppHarbor.Test
 			}
 
 			Api.DeleteApplication(ApplicationSlug);
-			var result = Api.CreateApplication(ApplicationSlug);
+			var result = Api.CreateApplication(ApplicationSlug, null);
 			Assert.IsNotNull(result);
 			Assert.IsNotNull(result.Id);
 			Assert.AreEqual(CreateStatus.Created, result.Status);

--- a/AppHarbor.Test/IntegrationTests.cs
+++ b/AppHarbor.Test/IntegrationTests.cs
@@ -17,7 +17,7 @@ namespace AppHarbor.Test
 		/// <summary>
 		/// This will be dynamically set to a unique name
 		/// </summary>
-		private static string ApplicationId;
+		private static string ApplicationSlug;
 
 		/// <summary>
 		/// Needs to be a valid Access Token
@@ -41,8 +41,8 @@ namespace AppHarbor.Test
 			}
 
 			// zzzintegration + first 20 chracters of newly created guid
-			// this should result in a fairly unique applicationid
-			ApplicationId = "zzzintegration" + Guid.NewGuid()
+			// this should result in a fairly unique applicationSlug
+			ApplicationSlug = "zzzintegration" + Guid.NewGuid()
 				.ToString("N")
 				.ToLower()
 				.Substring(0, 20);
@@ -52,14 +52,14 @@ namespace AppHarbor.Test
 
 		private void EnsureApplication()
 		{
-			var application = Api.GetApplication(ApplicationId);
+			var application = Api.GetApplication(ApplicationSlug);
 			if (application != null)
 			{
 				return;
 			}
 
-			Api.DeleteApplication(ApplicationId);
-			var result = Api.CreateApplication(ApplicationId, null);
+			Api.DeleteApplication(ApplicationSlug);
+			var result = Api.CreateApplication(ApplicationSlug);
 			Assert.IsNotNull(result);
 			Assert.IsNotNull(result.Id);
 			Assert.AreEqual(CreateStatus.Created, result.Status);
@@ -69,7 +69,7 @@ namespace AppHarbor.Test
 		[Priority(10)]
 		public void Create_Get_Edit_Delete_Application()
 		{
-			var result = Api.CreateApplication(ApplicationId, null);
+			var result = Api.CreateApplication(ApplicationSlug, null);
 			Assert.IsNotNull(result);
 			Assert.IsNotNull(result.Id);
 			Assert.AreEqual(CreateStatus.Created, result.Status);
@@ -90,7 +90,7 @@ namespace AppHarbor.Test
 			Assert.AreEqual(result.Id + "u", application.Name);
 			Assert.AreEqual("amazon-web-services::us-east-1", application.RegionIdentifier);
 
-			var deleted = Api.DeleteApplication(ApplicationId);
+			var deleted = Api.DeleteApplication(ApplicationSlug);
 			Assert.IsTrue(deleted);
 
 			application = Api.GetApplication(result.Id);
@@ -108,26 +108,26 @@ namespace AppHarbor.Test
 
 			EnsureApplication();
 
-			var result = Api.CreateCollaborator(ApplicationId, CollaboratorEmail, Model.CollaboratorType.Collaborator);
+			var result = Api.CreateCollaborator(ApplicationSlug, CollaboratorEmail, Model.CollaboratorType.Collaborator);
 			Assert.IsNotNull(result);
 			Assert.AreNotEqual(0, result.Id);
 			Assert.AreEqual(CreateStatus.Created, result.Status);
 
-			var item = Api.GetCollaborator(ApplicationId, result.Id);
+			var item = Api.GetCollaborator(ApplicationSlug, result.Id);
 			Assert.IsNotNull(item);
 			Assert.AreEqual(result.Id, item.Id);
 			Assert.AreEqual(CollaboratorType.Collaborator, item.Role);
 
 			item.Role = CollaboratorType.Administrator;
-			var updated = Api.EditCollaborator(ApplicationId, item);
+			var updated = Api.EditCollaborator(ApplicationSlug, item);
 			Assert.IsTrue(updated);
 
-			item = Api.GetCollaborator(ApplicationId, result.Id);
+			item = Api.GetCollaborator(ApplicationSlug, result.Id);
 			Assert.IsNotNull(item);
 			Assert.AreEqual(result.Id, item.Id);
 			Assert.AreEqual(CollaboratorType.Administrator, item.Role);
 
-			Api.DeleteCollaborator(ApplicationId, result.Id);
+			Api.DeleteCollaborator(ApplicationSlug, result.Id);
 		}
 
 		[TestMethod]
@@ -135,12 +135,12 @@ namespace AppHarbor.Test
 		{
 			EnsureApplication();
 
-			var result = Api.CreateConfigurationVariable(ApplicationId, "somekey", "somevalue");
+			var result = Api.CreateConfigurationVariable(ApplicationSlug, "somekey", "somevalue");
 			Assert.IsNotNull(result);
 			Assert.IsNotNull(result.Id);
 			Assert.AreEqual(CreateStatus.Created, result.Status);
 
-			var item = Api.GetConfigurationVariable(ApplicationId, result.Id);
+			var item = Api.GetConfigurationVariable(ApplicationSlug, result.Id);
 			Assert.IsNotNull(item);
 			Assert.AreEqual(result.Id, item.Id);
 			Assert.AreEqual("somekey", item.Key);
@@ -148,16 +148,16 @@ namespace AppHarbor.Test
 
 			item.Key = "somekeyu";
 			item.Value = "somevalueu";
-			var updated = Api.EditConfigurationVariable(ApplicationId, item);
+			var updated = Api.EditConfigurationVariable(ApplicationSlug, item);
 			Assert.IsTrue(updated);
 
-			item = Api.GetConfigurationVariable(ApplicationId, result.Id);
+			item = Api.GetConfigurationVariable(ApplicationSlug, result.Id);
 			Assert.IsNotNull(item);
 			Assert.AreEqual(result.Id, item.Id);
 			Assert.AreEqual("somekeyu", item.Key);
 			Assert.AreEqual("somevalueu", item.Value);
 
-			Api.DeleteConfigurationVariable(ApplicationId, result.Id);
+			Api.DeleteConfigurationVariable(ApplicationSlug, result.Id);
 		}
 
 		[TestMethod]
@@ -165,17 +165,17 @@ namespace AppHarbor.Test
 		{
 			EnsureApplication();
 
-			var result = Api.CreateHostname(ApplicationId, "some345345n4534host.com");
+			var result = Api.CreateHostname(ApplicationSlug, "some345345n4534host.com");
 			Assert.IsNotNull(result);
 			Assert.IsNotNull(result.Id);
 			Assert.AreEqual(CreateStatus.Created, result.Status);
 
-			var item = Api.GetHostname(ApplicationId, result.Id);
+			var item = Api.GetHostname(ApplicationSlug, result.Id);
 			Assert.IsNotNull(item);
 			Assert.AreEqual(result.Id, item.Id);
 			Assert.AreEqual("some345345n4534host.com", item.Value);
 
-			Api.DeleteHostname(ApplicationId, result.Id);
+			Api.DeleteHostname(ApplicationSlug, result.Id);
 		}
 
 		[TestMethod]
@@ -183,17 +183,17 @@ namespace AppHarbor.Test
 		{
 			EnsureApplication();
 
-			var result = Api.CreateServicehook(ApplicationId, "http://somehost.com");
+			var result = Api.CreateServicehook(ApplicationSlug, "http://somehost.com");
 			Assert.IsNotNull(result);
 			Assert.IsNotNull(result.Id);
 			Assert.AreEqual(CreateStatus.Created, result.Status);
 
-			var item = Api.GetServicehook(ApplicationId, result.Id);
+			var item = Api.GetServicehook(ApplicationSlug, result.Id);
 			Assert.IsNotNull(item);
 			Assert.AreEqual(result.Id, item.Id);
 			Assert.AreEqual("http://somehost.com", item.Value);
 
-			Api.DeleteServicehook(ApplicationId, result.Id);
+			Api.DeleteServicehook(ApplicationSlug, result.Id);
 		}
 
 		[ClassCleanup]

--- a/AppHarbor.Test/MockedApiTests.cs
+++ b/AppHarbor.Test/MockedApiTests.cs
@@ -13,7 +13,7 @@ namespace AppHarbor.Test
 		private static AppHarborClient Api;
 		private static AppHarborClient EmptyListDataApi;
 		private static AppHarborClient ExistingDataDataApi;
-		private static string ApplicationID;
+		private static string ApplicationSlug;
 
 		private class MockedAppHarborClient : AppHarborClient
 		{
@@ -40,23 +40,23 @@ namespace AppHarbor.Test
 			clientExistingData.HttpFactory = new RestSharp.SimpleFactory<ExistingDataMockHttp>();
 			ExistingDataDataApi = new MockedAppHarborClient(authInfo, clientExistingData);
 
-			ApplicationID = ":application";
+			ApplicationSlug = ":application";
 		}
 
 		[TestMethod]
 		public void Create_Non_Existing_Application()
 		{
-			var createResult = Api.CreateApplication(ApplicationID);
+			var createResult = Api.CreateApplication(ApplicationSlug);
 			Assert.IsNotNull(createResult);
 			Assert.AreEqual(CreateStatus.Created, createResult.Status);
-			Assert.AreEqual(ApplicationID, createResult.Id);
+			Assert.AreEqual(ApplicationSlug, createResult.Id);
 			Assert.AreEqual("https://appharbor.com/applications/:application", createResult.Location.AbsoluteUri);
 		}
 
 		[TestMethod]
 		public void Try_Create_Existing_Application()
 		{
-			var createResult = ExistingDataDataApi.CreateApplication(ApplicationID);
+			var createResult = ExistingDataDataApi.CreateApplication(ApplicationSlug);
 			Assert.IsNotNull(createResult);
 			Assert.AreEqual(CreateStatus.AlreadyExists, createResult.Status);
 			Assert.AreEqual(null, createResult.Id);
@@ -66,7 +66,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Create_Non_Existing_Collaborator()
 		{
-			var createResult = Api.CreateCollaborator(ApplicationID, "some@mail.com", CollaboratorType.Collaborator);
+			var createResult = Api.CreateCollaborator(ApplicationSlug, "some@mail.com", CollaboratorType.Collaborator);
 			Assert.IsNotNull(createResult);
 			Assert.AreEqual(CreateStatus.Created, createResult.Status);
 			Assert.AreEqual("5", createResult.Id);
@@ -76,7 +76,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Try_Create_Existing_Collaborator()
 		{
-			var createResult = ExistingDataDataApi.CreateCollaborator(ApplicationID, "some@mail.com", CollaboratorType.Collaborator);
+			var createResult = ExistingDataDataApi.CreateCollaborator(ApplicationSlug, "some@mail.com", CollaboratorType.Collaborator);
 			Assert.IsNotNull(createResult);
 			Assert.AreEqual(CreateStatus.AlreadyExists, createResult.Status);
 			Assert.IsNull(createResult.Id);
@@ -86,7 +86,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Create_Non_Existing_ConfigurationVariable()
 		{
-			var createResult = Api.CreateConfigurationVariable(ApplicationID, "somekey", "somevalue");
+			var createResult = Api.CreateConfigurationVariable(ApplicationSlug, "somekey", "somevalue");
 			Assert.IsNotNull(createResult);
 			Assert.AreEqual(CreateStatus.Created, createResult.Status);
 			Assert.AreEqual("5", createResult.Id);
@@ -96,7 +96,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Try_Create_Existing_ConfigurationVariable()
 		{
-			var createResult = ExistingDataDataApi.CreateConfigurationVariable(ApplicationID, "somekey", "somevalue");
+			var createResult = ExistingDataDataApi.CreateConfigurationVariable(ApplicationSlug, "somekey", "somevalue");
 			Assert.IsNotNull(createResult);
 			Assert.AreEqual(CreateStatus.AlreadyExists, createResult.Status);
 			Assert.IsNull(createResult.Id);
@@ -106,7 +106,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Create_Non_Existing_Hostname()
 		{
-			var createResult = Api.CreateHostname(ApplicationID, "somehostname.com");
+			var createResult = Api.CreateHostname(ApplicationSlug, "somehostname.com");
 			Assert.IsNotNull(createResult);
 			Assert.AreEqual(CreateStatus.Created, createResult.Status);
 			Assert.AreEqual("5", createResult.Id);
@@ -116,7 +116,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Try_Create_Existing_Hostname()
 		{
-			var createResult = ExistingDataDataApi.CreateHostname(ApplicationID, "somehostname.com");
+			var createResult = ExistingDataDataApi.CreateHostname(ApplicationSlug, "somehostname.com");
 			Assert.IsNotNull(createResult);
 			Assert.AreEqual(CreateStatus.AlreadyExists, createResult.Status);
 			Assert.IsNull(createResult.Id);
@@ -126,7 +126,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Create_Non_Existing_ServiceHook()
 		{
-			var createResult = Api.CreateServicehook(ApplicationID, "http://someurl.com");
+			var createResult = Api.CreateServicehook(ApplicationSlug, "http://someurl.com");
 			Assert.IsNotNull(createResult);
 			Assert.AreEqual(CreateStatus.Created, createResult.Status);
 			Assert.AreEqual("5", createResult.Id);
@@ -136,7 +136,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Try_Create_Existing_ServiceHook()
 		{
-			var createResult = ExistingDataDataApi.CreateServicehook(ApplicationID, "http://someurl.com");
+			var createResult = ExistingDataDataApi.CreateServicehook(ApplicationSlug, "http://someurl.com");
 			Assert.IsNotNull(createResult);
 			Assert.AreEqual(CreateStatus.AlreadyExists, createResult.Status);
 			Assert.IsNull(createResult.Id);
@@ -146,7 +146,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Edit_Existing_Application()
 		{
-			var edited = Api.EditApplication(ApplicationID, new Application
+			var edited = Api.EditApplication(ApplicationSlug, new Application
 			{
 				Name = "SomeName"
 			});
@@ -166,7 +166,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Edit_Existing_Collaborator()
 		{
-			var edited = Api.EditCollaborator(ApplicationID, new Collaborator
+			var edited = Api.EditCollaborator(ApplicationSlug, new Collaborator
 			{
 				Id = "5",
 				Role = CollaboratorType.Collaborator,
@@ -177,7 +177,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Edit_Non_Existing_Collaborator()
 		{
-			var edited = Api.EditCollaborator(ApplicationID, new Collaborator
+			var edited = Api.EditCollaborator(ApplicationSlug, new Collaborator
 			{
 				Id = "6",
 				Role = CollaboratorType.Collaborator,
@@ -188,7 +188,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Edit_Existing_ConfigurationVariable()
 		{
-			var edited = Api.EditConfigurationVariable(ApplicationID, new ConfigurationVariable
+			var edited = Api.EditConfigurationVariable(ApplicationSlug, new ConfigurationVariable
 			{
 				Id = "5",
 				Key = "somekey",
@@ -200,7 +200,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Edit_Non_Existing_ConfigurationVariable()
 		{
-			var edited = Api.EditConfigurationVariable(ApplicationID, new ConfigurationVariable
+			var edited = Api.EditConfigurationVariable(ApplicationSlug, new ConfigurationVariable
 			{
 				Id = "6",
 				Key = "somekey",
@@ -212,7 +212,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Delete_Existing_Application()
 		{
-			var deleted = Api.DeleteApplication(ApplicationID);
+			var deleted = Api.DeleteApplication(ApplicationSlug);
 			Assert.IsTrue(deleted);
 		}
 
@@ -226,56 +226,56 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Delete_Existing_Collaborator()
 		{
-			var deleted = Api.DeleteCollaborator(ApplicationID, "5");
+			var deleted = Api.DeleteCollaborator(ApplicationSlug, "5");
 			Assert.IsTrue(deleted);
 		}
 
 		[TestMethod]
 		public void Delete_Non_Existing_Collaborator()
 		{
-			var deleted = Api.DeleteCollaborator(ApplicationID, "6");
+			var deleted = Api.DeleteCollaborator(ApplicationSlug, "6");
 			Assert.IsFalse(deleted);
 		}
 
 		[TestMethod]
 		public void Delete_Existing_ConfigurationVariable()
 		{
-			var deleted = Api.DeleteConfigurationVariable(ApplicationID, "5");
+			var deleted = Api.DeleteConfigurationVariable(ApplicationSlug, "5");
 			Assert.IsTrue(deleted);
 		}
 
 		[TestMethod]
 		public void Delete_Non_Existing_ConfigurationVariable()
 		{
-			var deleted = Api.DeleteConfigurationVariable(ApplicationID, "6");
+			var deleted = Api.DeleteConfigurationVariable(ApplicationSlug, "6");
 			Assert.IsFalse(deleted);
 		}
 
 		[TestMethod]
 		public void Delete_Existing_Hostname()
 		{
-			var deleted = Api.DeleteHostname(ApplicationID, "5");
+			var deleted = Api.DeleteHostname(ApplicationSlug, "5");
 			Assert.IsTrue(deleted);
 		}
 
 		[TestMethod]
 		public void Delete_Non_Existing_Hostname()
 		{
-			var deleted = Api.DeleteHostname(ApplicationID, "6");
+			var deleted = Api.DeleteHostname(ApplicationSlug, "6");
 			Assert.IsFalse(deleted);
 		}
 
 		[TestMethod]
 		public void Delete_Existing_Servicehook()
 		{
-			var deleted = Api.DeleteServicehook(ApplicationID, "5");
+			var deleted = Api.DeleteServicehook(ApplicationSlug, "5");
 			Assert.IsTrue(deleted);
 		}
 
 		[TestMethod]
 		public void Delete_Non_Existing_Servicehook()
 		{
-			var deleted = Api.DeleteServicehook(ApplicationID, "6");
+			var deleted = Api.DeleteServicehook(ApplicationSlug, "6");
 			Assert.IsFalse(deleted);
 		}
 
@@ -301,7 +301,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Existing_Application()
 		{
-			var item = Api.GetApplication(ApplicationID);
+			var item = Api.GetApplication(ApplicationSlug);
 			Assert.IsNotNull(item);
 			Assert.AreEqual(item.Name, "Hello World");
 			Assert.AreEqual(item.Slug, "helloworld");
@@ -317,7 +317,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Non_Empty_Collaborator_List()
 		{
-			var items = Api.GetCollaborators(ApplicationID);
+			var items = Api.GetCollaborators(ApplicationSlug);
 
 			Assert.IsNotNull(items);
 			Assert.IsTrue(items.Count() == 1);
@@ -335,7 +335,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Empty_Collaborator_List()
 		{
-			var items = EmptyListDataApi.GetCollaborators(ApplicationID);
+			var items = EmptyListDataApi.GetCollaborators(ApplicationSlug);
 
 			Assert.IsNotNull(items);
 			Assert.IsTrue(!items.Any());
@@ -344,7 +344,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Existing_Collaborator()
 		{
-			var item = Api.GetCollaborator(ApplicationID, "5");
+			var item = Api.GetCollaborator(ApplicationSlug, "5");
 			Assert.AreEqual(item.Id, "5");
 			Assert.AreEqual(item.Role, CollaboratorType.Collaborator);
 			Assert.AreEqual(item.Url, "https://appharbor.com/applications/:application/collaborators/5");
@@ -357,14 +357,14 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Null_For_Non_Existing_Collaborator()
 		{
-			var item = Api.GetCollaborator(ApplicationID, "6");
+			var item = Api.GetCollaborator(ApplicationSlug, "6");
 			Assert.IsNull(item);
 		}
 
 		[TestMethod]
 		public void Get_Non_Empty_ConfigurationVariable_List()
 		{
-			var items = Api.GetConfigurationVariables(ApplicationID);
+			var items = Api.GetConfigurationVariables(ApplicationSlug);
 
 			Assert.IsNotNull(items);
 			Assert.IsTrue(items.Count() == 1);
@@ -379,7 +379,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Empty_ConfigurationVariable_List()
 		{
-			var items = EmptyListDataApi.GetConfigurationVariables(ApplicationID);
+			var items = EmptyListDataApi.GetConfigurationVariables(ApplicationSlug);
 
 			Assert.IsNotNull(items);
 			Assert.IsTrue(!items.Any());
@@ -388,7 +388,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Existing_ConfigurationVariable()
 		{
-			var item = Api.GetConfigurationVariable(ApplicationID, "5");
+			var item = Api.GetConfigurationVariable(ApplicationSlug, "5");
 			Assert.AreEqual(item.Id, "5");
 			Assert.AreEqual(item.Key, "foo");
 			Assert.AreEqual(item.Value, "bar");
@@ -398,14 +398,14 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Null_For_Non_Existing_ConfigurationVariable()
 		{
-			var item = Api.GetConfigurationVariable(ApplicationID, "6");
+			var item = Api.GetConfigurationVariable(ApplicationSlug, "6");
 			Assert.IsNull(item);
 		}
 
 		[TestMethod]
 		public void Get_Non_Empty_Hostname_List()
 		{
-			var items = Api.GetHostnames(ApplicationID);
+			var items = Api.GetHostnames(ApplicationSlug);
 
 			Assert.IsNotNull(items);
 			Assert.IsTrue(items.Count() == 1);
@@ -420,7 +420,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Empty_Hostname_List()
 		{
-			var items = EmptyListDataApi.GetHostnames(ApplicationID);
+			var items = EmptyListDataApi.GetHostnames(ApplicationSlug);
 
 			Assert.IsNotNull(items);
 			Assert.IsTrue(!items.Any());
@@ -429,7 +429,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Existing_Hostname()
 		{
-			var item = Api.GetHostname(ApplicationID, "5");
+			var item = Api.GetHostname(ApplicationSlug, "5");
 			Assert.AreEqual(item.Id, "5");
 			Assert.AreEqual(item.Value, "example.org");
 			Assert.AreEqual(item.Canonical, false);
@@ -439,14 +439,14 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Null_For_Non_Existing_Hostname()
 		{
-			var item = Api.GetHostname(ApplicationID, "6");
+			var item = Api.GetHostname(ApplicationSlug, "6");
 			Assert.IsNull(item);
 		}
 
 		[TestMethod]
 		public void Get_Non_Empty_Servicehook_List()
 		{
-			var items = Api.GetServicehooks(ApplicationID);
+			var items = Api.GetServicehooks(ApplicationSlug);
 
 			Assert.IsNotNull(items);
 			Assert.IsTrue(items.Count() == 1);
@@ -460,7 +460,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Empty_Servicehook_List()
 		{
-			var items = EmptyListDataApi.GetServicehooks(ApplicationID);
+			var items = EmptyListDataApi.GetServicehooks(ApplicationSlug);
 
 			Assert.IsNotNull(items);
 			Assert.IsTrue(!items.Any());
@@ -469,7 +469,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Existing_Servicehook()
 		{
-			var item = Api.GetServicehook(ApplicationID, "5");
+			var item = Api.GetServicehook(ApplicationSlug, "5");
 			Assert.AreEqual(item.Id, "5");
 			Assert.AreEqual(item.Value, "http://www.example.org");
 			Assert.AreEqual(item.Url, "https://appharbor.com/applications/:application/servicehooks/5");
@@ -478,14 +478,14 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Null_For_Non_Existing_Servicehook()
 		{
-			var item = Api.GetServicehook(ApplicationID, "6");
+			var item = Api.GetServicehook(ApplicationSlug, "6");
 			Assert.IsNull(item);
 		}
 
 		[TestMethod]
 		public void Get_Non_Empty_Build_List()
 		{
-			var items = Api.GetBuilds(ApplicationID);
+			var items = Api.GetBuilds(ApplicationSlug);
 
 			Assert.IsNotNull(items);
 			Assert.IsTrue(items.Count() == 1);
@@ -507,7 +507,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Empty_Build_List()
 		{
-			var items = EmptyListDataApi.GetBuilds(ApplicationID);
+			var items = EmptyListDataApi.GetBuilds(ApplicationSlug);
 
 			Assert.IsNotNull(items);
 			Assert.IsTrue(!items.Any());
@@ -516,7 +516,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Existing_Build()
 		{
-			var item = Api.GetBuild(ApplicationID, "5");
+			var item = Api.GetBuild(ApplicationSlug, "5");
 			Assert.AreEqual("5", item.Id);
 			Assert.AreEqual("Succeeded", item.Status);
 			Assert.AreEqual(new DateTime(2012, 02, 28, 13, 36, 30), item.Created);
@@ -533,14 +533,14 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Null_For_Non_Existing_Build()
 		{
-			var item = Api.GetBuild(ApplicationID, "6");
+			var item = Api.GetBuild(ApplicationSlug, "6");
 			Assert.IsNull(item);
 		}
 
 		[TestMethod]
 		public void Get_Non_Empty_Test_List_For_Existing_Build()
 		{
-			var items = Api.GetTests(ApplicationID, "5");
+			var items = Api.GetTests(ApplicationSlug, "5");
 
 			Assert.IsNotNull(items);
 			Assert.AreEqual(2, items.Count());
@@ -599,7 +599,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Empty_Test_List_For_Existing_Build()
 		{
-			var items = EmptyListDataApi.GetTests(ApplicationID, "5");
+			var items = EmptyListDataApi.GetTests(ApplicationSlug, "5");
 
 			Assert.IsNotNull(items);
 			Assert.IsTrue(!items.Any());
@@ -608,7 +608,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Existing_Test()
 		{
-			var item = Api.GetTest(ApplicationID, "5", "3.1");
+			var item = Api.GetTest(ApplicationSlug, "5", "3.1");
 			Assert.AreEqual("3.1", item.Id);
 			Assert.AreEqual("ShouldReturnFooWhenBarIsCalled", item.Name);
 			Assert.AreEqual("Passed", item.Status);
@@ -622,21 +622,21 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Null_For_Non_Existing_Test()
 		{
-			var item = Api.GetTest(ApplicationID, "5", "6");
+			var item = Api.GetTest(ApplicationSlug, "5", "6");
 			Assert.IsNull(item);
 		}
 
 		[TestMethod]
 		public void Get_Null_Test_List_For_Non_Existing_Build()
 		{
-			var item = Api.GetTest(ApplicationID, "6", "6");
+			var item = Api.GetTest(ApplicationSlug, "6", "6");
 			Assert.IsNull(item);
 		}
 
 		[TestMethod]
 		public void Get_Errors()
 		{
-			var items = Api.GetErrors(ApplicationID);
+			var items = Api.GetErrors(ApplicationSlug);
 
 			Assert.IsNotNull(items);
 			Assert.IsTrue(items.Count() == 1);
@@ -659,7 +659,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Existing_Error()
 		{
-			var item = Api.GetError(ApplicationID, "5");
+			var item = Api.GetError(ApplicationSlug, "5");
 			Assert.AreEqual("5", item.Id);
 			Assert.AreEqual("foo", item.Commit_Id);
 			Assert.AreEqual(new DateTime(2012, 03, 05, 15, 01, 42), item.Date);
@@ -677,7 +677,7 @@ namespace AppHarbor.Test
 		[TestMethod]
 		public void Get_Null_For_Non_Existing_Error()
 		{
-			var item = Api.GetError(ApplicationID, "6");
+			var item = Api.GetError(ApplicationSlug, "6");
 			Assert.IsNull(item);
 		}
 


### PR DESCRIPTION
Something I noticed is that your documentation refers to ApplicationSlugs not ApplicationIds and I initially went hunting for an AppId only to discover they are the same thing.  Therefire, I changed the code to reflect this and save someone else the trouble.

Please note that I was unable to run the Integration tests as I am a free user and as such do not have permissions to create Hostnames and suchlike.
