### PR TITLE
Add count and offset query string support to builds

### DIFF
--- a/AppHarbor.Sdk/AppHarborClient.Build.cs
+++ b/AppHarbor.Sdk/AppHarborClient.Build.cs
@@ -18,13 +18,15 @@ namespace AppHarbor
 			return ExecuteGetKeyed<Build>(request);
 		}
 
-		public IEnumerable<Build> GetBuilds(string applicationSlug)
+		public IEnumerable<Build> GetBuilds(string applicationSlug, int? count = null, int? offset = null)
 		{
 			CheckArgumentNull("applicationSlug", applicationSlug);
 
 			var request = new RestRequest();
-			request.Resource = "applications/{applicationSlug}/builds";
+			request.Resource = "applications/{applicationSlug}/builds?count={count}&offset={offset}";
 			request.AddParameter("applicationSlug", applicationSlug, ParameterType.UrlSegment);
+			request.AddParameter("count", count.ToString(), ParameterType.UrlSegment);
+			request.AddParameter("offset", offset.ToString(), ParameterType.UrlSegment);
 
 			return ExecuteGetListKeyed<Build>(request);
 		}


### PR DESCRIPTION
Add `count` and `offset` query string support to `/applications/:slug/builds`.
See discussion here: http://support.appharbor.com/discussions/problems/26870-api-performance-issue-for-builds
